### PR TITLE
RTC support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +166,7 @@ name = "gbc"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "chrono",
  "log",
  "serde",
 ]
@@ -226,6 +241,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
+ "autocfg",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
  "autocfg",
 ]
 
@@ -433,6 +467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +517,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/emu/src/main.rs
+++ b/emu/src/main.rs
@@ -15,13 +15,13 @@ use sdl2::video::Window;
 use structopt::StructOpt;
 
 struct FpsCounter {
-    // FPS calculation
     start_time: Instant,
     last_elapsed: Duration,
     frame_count: u64,
 }
 
 impl FpsCounter {
+    /// The weight for older frames - current frame gets 1 - WEIGHT
     const WEIGHT: f32 = 0.1;
 
     pub fn new() -> Self {
@@ -32,7 +32,7 @@ impl FpsCounter {
         }
     }
 
-    // Records a new frame and outputs the current FPS
+    /// Records a new frame and outputs the current FPS
     pub fn frame(&mut self) -> f32 {
         self.frame_count += 1;
 
@@ -204,7 +204,8 @@ fn gui(rom_file: PathBuf, scale: u32, speed: u8, boot_rom: bool, trace: bool) {
     let height = LCD_HEIGHT as u32 * scale;
 
     // Setup an SDL2 Window
-    let window = video_subsystem.window(rom_name, width, height)
+    let window = video_subsystem
+        .window(rom_name, width, height)
         .position_centered()
         .allow_highdpi()
         .resizable()
@@ -214,10 +215,11 @@ fn gui(rom_file: PathBuf, scale: u32, speed: u8, boot_rom: bool, trace: bool) {
     // Convert the Window into a Canvas
     // This is what we will use to render content in the Window
     // TODO: Add flag for software vs. GPU
-    let mut canvas = window.into_canvas()
-                           .software()
-                           .build()
-                           .unwrap();
+    let mut canvas = window
+        .into_canvas()
+        .software()
+        .build()
+        .unwrap();
 
     // Fix aspect ratio of canvas
     canvas.set_logical_size(width, height).unwrap();

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [features]
 default = ["save"]
 debug = []
-save = ["serde", "bincode", "chrono/serde"]
+save = []
 
 [dependencies]
 log = "0.4"
-chrono = { version = "0.4" }
-serde = { version = "1", features = ["derive"], optional = true }
-bincode = { version = "1", optional = true }
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+bincode = { version = "1" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2018"
 [features]
 default = ["save"]
 debug = []
-save = ["serde", "bincode"]
+save = ["serde", "bincode", "chrono/serde"]
 
 [dependencies]
 log = "0.4"
+chrono = { version = "0.4" }
 serde = { version = "1", features = ["derive"], optional = true }
 bincode = { version = "1", optional = true }

--- a/lib/src/cartridge.rs
+++ b/lib/src/cartridge.rs
@@ -441,7 +441,7 @@ impl Controller {
 
         let rtc = if cartridge_type.is_rtc() {
             let mut rtc = Rtc::new();
-            rtc.enable_battery(&cartridge.rom_path, false)?;
+            rtc.with_file(&cartridge.rom_path, false)?;
             rtc.into()
         } else {
             None
@@ -486,7 +486,7 @@ impl Controller {
                 Some(rtc) => rtc,
             };
 
-            rtc.enable_battery(&rom_path, true)?;
+            rtc.with_file(&rom_path, true)?;
         }
 
         Ok(())

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -5,6 +5,7 @@ pub enum Error {
     IoError(String),
     Utf8Error(String),
     InvalidValue(String),
+    BincodeError(String),
 }
 
 impl std::error::Error for Error {}
@@ -15,6 +16,7 @@ impl std::fmt::Display for Error {
             Self::IoError(msg) => write!(f, "I/O error: {}", msg),
             Self::Utf8Error(msg) => write!(f, "UTF8 decoding error: {}", msg),
             Self::InvalidValue(msg) => write!(f, "Invalid value: {}", msg),
+            Self::BincodeError(msg) => write!(f, "Bincode error: {}", msg),
         }
     }
 }
@@ -28,5 +30,11 @@ impl From<std::io::Error> for Error {
 impl From<std::str::Utf8Error> for Error {
     fn from(err: std::str::Utf8Error) -> Self {
         Self::Utf8Error(err.to_string())
+    }
+}
+
+impl From<Box<bincode::ErrorKind>> for Error {
+    fn from(err: Box<bincode::ErrorKind>) -> Self {
+        Self::BincodeError(err.to_string())
     }
 }

--- a/lib/src/rtc.rs
+++ b/lib/src/rtc.rs
@@ -1,0 +1,255 @@
+//! Real-time Clock implementation for MBC3.
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+
+use crate::cpu::Cpu;
+use crate::error::Result;
+
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "save", derive(serde::Serialize), derive(serde::Deserialize))]
+pub struct RtcTime {
+    pub seconds: u8,
+    pub minutes: u8,
+    pub hours: u8,
+    pub days: u16, 
+    pub halt: bool,
+    pub carry: bool,
+}
+
+impl RtcTime {
+    pub fn new() -> Self {
+        Self {
+            seconds: 0,
+            minutes: 0,
+            hours: 0,
+            days: 0,
+            halt: false,
+            carry: false,
+        }
+    }
+}
+
+#[cfg_attr(feature = "save", derive(serde::Serialize), derive(serde::Deserialize))]
+/// Real-time Clock implementation for MBC3
+///
+/// On every tick of the clock, the last UTC timestamp is written
+/// to a backing file, if any.
+pub struct Rtc {
+    /// Current time
+    current: RtcTime,
+
+    /// Latched time
+    latched: RtcTime,
+
+    latch_started: bool,
+
+    /// Last timestamp
+    timestamp: DateTime<Utc>,
+
+    /// Last tick cycle
+    tick_cycle: u64,
+
+    /// Last cycle seen
+    cycle: u64,
+
+    /// Selected register
+    selected: u8,
+
+    /// Backing file
+    #[cfg_attr(feature = "save", serde(skip))]
+    file: Option<File>,
+}
+
+impl Rtc {
+    // Tick interval for the RTC, in ns
+    const TICK_INTERVAL: u64 = (1e9 / 32768 as f32) as u64;
+
+    pub fn new() -> Self {
+        Self {
+            current: RtcTime::new(),
+            latched: RtcTime::new(),
+            latch_started: false,
+            timestamp: Utc::now(),
+            tick_cycle: 0,
+            cycle: 0,
+            selected: 0,
+            file: None,
+        }
+    }
+
+    pub fn step(&mut self, cycles: u16, speed: bool) {
+        let cycle_time = Cpu::cycle_time(speed) as u64;
+
+        if self.current.halt {
+            // Clock is halted
+            return;
+        }
+
+        self.cycle += cycles as u64;
+
+        if (self.cycle - self.tick_cycle) / cycle_time >= Self::TICK_INTERVAL {
+            self.tick();
+        }
+    }
+
+    fn tick(&mut self) {
+        self.current.seconds += 1;
+
+        if self.current.seconds > 0x3B {
+            self.current.seconds = 0;
+            self.current.minutes += 1;
+        }
+
+        if self.current.minutes > 0x3B {
+            self.current.minutes = 0;
+            self.current.hours += 1;
+        }
+
+        if self.current.hours > 0x17 {
+            self.current.hours = 0;
+            self.current.days += 1;
+        }
+
+        if self.current.days > 0x1FF {
+            self.current.days = 0;
+            self.current.carry = true;
+        }
+
+        self.timestamp = Utc::now();
+        self.tick_cycle = self.cycle;
+
+        if let Some(file) = &mut self.file {
+            file.seek(SeekFrom::Start(0)).unwrap();
+            file.write(self.timestamp.to_rfc3339().as_bytes()).unwrap();
+        }
+    }
+
+    pub fn select(&mut self, register: u8) {
+        self.selected = register;
+    }
+
+    pub fn latch(&mut self, value: u8) {
+        if value == 0 {
+            self.latch_started = true;
+        } else if self.latch_started {
+            self.latched = self.current;
+            self.latch_started = false;
+        }
+    }
+
+    pub fn read(&self) -> u8 {
+        match self.selected {
+            0x08 => {
+                // Seconds
+                self.latched.seconds
+            }
+            0x09 => {
+                // Minutes
+                self.latched.minutes
+            }
+            0x0A => {
+                // Hours
+                self.latched.hours
+            }
+            0x0B => {
+                // Lower 8 bits of day
+                (self.latched.days & 0xFF) as u8
+            }
+            0x0C => {
+                // Upper bit of day, carry bit, halt flag
+                let mut value = (self.latched.days & 1 << 8 >> 8) as u8;
+                let halt_bit = if self.latched.halt {
+                    1
+                } else {
+                    0
+                };
+                let carry_bit = if self.latched.carry {
+                    1
+                } else {
+                    0
+                };
+
+                value |= halt_bit << 6;
+                value |= carry_bit << 7;
+
+                value
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn write(&mut self, value: u8) {
+        match self.selected {
+            0x08 => {
+                // Seconds
+                self.current.seconds = value;
+            }
+            0x09 => {
+                // Minutes
+                self.current.minutes = value;
+            }
+            0x0A => {
+                // Hours
+                self.current.hours = value;
+            }
+            0x0B => {
+                // Lower 8 bits of day
+                self.current.days |= value as u16;
+            }
+            0x0C => {
+                // Upper bit of day, carry bit, halt flag
+                self.current.days &= !(1 << 8);
+                self.current.days |= (value as u16 & 1) << 8;
+                self.current.halt = value & 1 << 6 != 0;
+                self.current.carry = value & 1 << 7 != 0;
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// If an RTC file exists, load timestamp from the file. Otherwise, create a new one.
+    ///
+    /// Once a timestamp is loaded, adjust current clock based on difference between it and the
+    /// last timestamp.
+    ///
+    /// If `overwrite` is `true`, overwrite any existing file with the current state. This
+    /// is used when loading from a save state.
+    pub fn enable_battery<P: AsRef<Path>>(&mut self, rom_path: P, overwrite: bool) -> Result<()> {
+        let rtc_path = rom_path.as_ref().with_extension("rtc");
+        let mut rtc_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(rtc_path)?;
+
+        if overwrite {
+            // Overwrite the contents of the backing file
+            let s = self.timestamp.to_rfc3339();
+            rtc_file.write_all(s.as_bytes())?;
+            self.file = Some(rtc_file);
+            return Ok(());
+        }
+
+        let timestamp = if rtc_file.metadata()?.len() != 0 {
+            // Load last timestamp from the file
+            let mut s = String::new();
+            rtc_file.read_to_string(&mut s)?;
+            DateTime::parse_from_rfc3339(&s)
+                .expect("Failed to parse time from file")
+                .with_timezone(&Utc)
+                .into()
+        } else {
+            None
+        };
+
+        if let Some(timestamp) = timestamp {
+
+        }
+
+        // TODO
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a basic RTC implementation. This is not even close to an accurate implementation, but should be "good enough" for now.

As part of this change, both Serde and Bincode have been added as dependencies in order to be able to easily dump RTC state to a file. Save-state-related derives are still hidden behind the "save" feature flag.

